### PR TITLE
Fix indexing to work with new scraper, Cleanup

### DIFF
--- a/searchIndex/src/main/java/org/ezcampus/search/System/GlobalSettings.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/System/GlobalSettings.java
@@ -7,6 +7,7 @@ public class GlobalSettings
     public static final String BRAND = "searchIndex";
     public static final String BRAND_LONG = "SchedulePlatform-" + BRAND;
     public static boolean IS_DEBUG = false;
+    public static boolean DEBUG_LOG_INSERTING_WORDS = false;
 
     public static final int THUMBNAIL_SIZE = 256;
 

--- a/searchIndex/src/main/java/org/ezcampus/search/api/EndpointIndex.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/api/EndpointIndex.java
@@ -33,8 +33,8 @@ public class EndpointIndex
 		StatusResponse s = new StatusResponse();
 		s.isProcessing = DatabaseProcessing.isProcessing();
 		s.startTime = DatabaseProcessing.getStartTime();
-		s.timeSinceStart = DatabaseProcessing.getProcessElapsedTime();
-		s.timeSinceStartPretty = StringHelper.getEllapsedTimePretty(s.timeSinceStart);
+		s.elapsedTime = DatabaseProcessing.getProcessElapsedTimeMS();
+		s.elapsedTimePretty = StringHelper.getEllapsedTimePretty(s.elapsedTime);
 		
 		try
 		{

--- a/searchIndex/src/main/java/org/ezcampus/search/core/models/response/StatusResponse.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/core/models/response/StatusResponse.java
@@ -11,8 +11,8 @@ public class StatusResponse
 	public long startTime;
 	
 	@JsonProperty("elapsed_time")
-	public long timeSinceStart;
+	public long elapsedTime;
 	
 	@JsonProperty("elapsed_time_pretty")
-	public String timeSinceStartPretty;
+	public String elapsedTimePretty;
 }

--- a/searchIndex/src/main/java/org/ezcampus/search/data/StringHelper.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/data/StringHelper.java
@@ -7,17 +7,42 @@ import java.util.regex.Pattern;
 
 public class StringHelper
 {
-	public static String getEllapsedTimePretty(long startTimeNano) {
-
-		long elapsedTime = System.nanoTime() - startTimeNano;
-
-		// nanoseconds to milliseconds
-        long elapsedTimeMillis = (long) (elapsedTime / 1e6);
-
-        return String.format("Elapsed Time: %s", TimeHelper.GetFormattedInterval(elapsedTimeMillis));
-
+	public static String getEllapsedTimePretty(long elapsedTimeMS) 
+	{
+        return String.format("Elapsed Time: %s", TimeHelper.GetFormattedInterval(elapsedTimeMS));
 	}
 	
+    public static String getSpecialCharacterMapping(String value)
+    {
+        switch (value)
+        {
+	        case "&&":
+	        case "&":
+	        	return "and";
+	        case "||":
+	        	return "or";
+        }
+        return null;
+    }
+	
+    public static String getNumberMapping(String value)
+    {
+        switch (value)
+        {
+        case "0": return "zero";
+        case "1": return "one";
+        case "2": return "two";
+        case "3": return "three";
+        case "4": return "four";
+        case "5": return "five";
+        case "6": return "six";
+        case "7": return "seven";
+        case "8": return "eight";
+        case "9": return "nine";
+        }
+        return null;
+    }
+    
     public static String getRomanNumeralMapping(String value)
     {
         switch (value)
@@ -32,12 +57,11 @@ public class StringHelper
                 return "4";
             case "V":
                 return "5";
-            default:
-                return null;
         }
+        return null;
     }
 
-	private static final Pattern CLEAN_REGEX = Pattern.compile("[^a-z0-9']+");
+	private static final Pattern CLEAN_REGEX = Pattern.compile("[^a-z0-9'\"-]+");
 
 	public static String cleanWord(String word)
 	{

--- a/searchIndex/src/main/java/org/ezcampus/search/hibernate/entity/CourseData.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/hibernate/entity/CourseData.java
@@ -13,9 +13,10 @@ import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(name = "tbl_course_data", uniqueConstraints = @UniqueConstraint(columnNames = { "course_id", "crn" }))
-public class CourseData {
-
+@Table(name = "tbl_course_data", uniqueConstraints = @UniqueConstraint(columnNames = { "course_id", "crn"
+}))
+public class CourseData
+{
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "course_data_id")
@@ -60,278 +61,215 @@ public class CourseData {
 	@Column(name = "delivery")
 	private String delivery;
 
-	@ManyToOne(fetch=FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "course_id", referencedColumnName = "course_id")
 	private Course course;
 
-	@ManyToOne(fetch=FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "class_type_id", referencedColumnName = "class_type_id")
 	private ClassType classType;
 
-	@ManyToOne(fetch=FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "subject_id", referencedColumnName = "subject_id")
 	private Subject subject;
 
 	@JoinColumn(name = "scrape_id", referencedColumnName = "scrape_id")
-    @ManyToOne(fetch=FetchType.LAZY)
-    private ScrapeHistory scrapeId;
-   
+	@ManyToOne(fetch = FetchType.LAZY)
+	private ScrapeHistory scrapeId;
+
 	@Column(name = "should_be_indexed")
 	private Boolean shouldBeIndexed;
-	
-    public Integer getCourseDataId()
+
+	@Transient
+	public int ranking = 1;
+
+	public Integer getCourseDataId()
 	{
 		return courseDataId;
 	}
-
-
 
 	public void setCourseDataId(Integer courseDataId)
 	{
 		this.courseDataId = courseDataId;
 	}
 
-
-
 	public String getCrn()
 	{
 		return crn;
 	}
-
-
 
 	public void setCrn(String crn)
 	{
 		this.crn = crn;
 	}
 
-
-
 	public String getCourseTitle()
 	{
 		return courseTitle;
 	}
-
-
 
 	public void setCourseTitle(String courseTitle)
 	{
 		this.courseTitle = courseTitle;
 	}
 
-
-
 	public String getSequenceNumber()
 	{
 		return sequenceNumber;
 	}
-
-
 
 	public void setSequenceNumber(String sequenceNumber)
 	{
 		this.sequenceNumber = sequenceNumber;
 	}
 
-
-
 	public String getCampusDescription()
 	{
 		return campusDescription;
 	}
-
-
 
 	public void setCampusDescription(String campusDescription)
 	{
 		this.campusDescription = campusDescription;
 	}
 
-
-
 	public Integer getCreditHours()
 	{
 		return creditHours;
 	}
-
-
 
 	public void setCreditHours(Integer creditHours)
 	{
 		this.creditHours = creditHours;
 	}
 
-
-
 	public Integer getMaximumEnrollment()
 	{
 		return maximumEnrollment;
 	}
-
-
 
 	public void setMaximumEnrollment(Integer maximumEnrollment)
 	{
 		this.maximumEnrollment = maximumEnrollment;
 	}
 
-
-
 	public Integer getCurrentEnrollment()
 	{
 		return currentEnrollment;
 	}
-
-
 
 	public void setCurrentEnrollment(Integer currentEnrollment)
 	{
 		this.currentEnrollment = currentEnrollment;
 	}
 
-
-
 	public Integer getMaximumWaitlist()
 	{
 		return maximumWaitlist;
 	}
-
-
 
 	public void setMaximumWaitlist(Integer maximumWaitlist)
 	{
 		this.maximumWaitlist = maximumWaitlist;
 	}
 
-
-
 	public Integer getCurrentWaitlist()
 	{
 		return currentWaitlist;
 	}
-
-
 
 	public void setCurrentWaitlist(Integer currentWaitlist)
 	{
 		this.currentWaitlist = currentWaitlist;
 	}
 
-
-
 	public Boolean getOpenSection()
 	{
 		return openSection;
 	}
-
-
 
 	public void setOpenSection(Boolean openSection)
 	{
 		this.openSection = openSection;
 	}
 
-
-
 	public String getLinkIdentifier()
 	{
 		return linkIdentifier;
 	}
-
-
 
 	public void setLinkIdentifier(String linkIdentifier)
 	{
 		this.linkIdentifier = linkIdentifier;
 	}
 
-
-
 	public Boolean getIsSectionLinked()
 	{
 		return isSectionLinked;
 	}
-
-
 
 	public void setIsSectionLinked(Boolean isSectionLinked)
 	{
 		this.isSectionLinked = isSectionLinked;
 	}
 
-
-
 	public String getDelivery()
 	{
 		return delivery;
 	}
-
-
 
 	public void setDelivery(String delivery)
 	{
 		this.delivery = delivery;
 	}
 
-
-
 	public Course getCourse()
 	{
 		return course;
 	}
-
-
+	
+	public Boolean getShouldBeIndexed() 
+	{
+		return this.shouldBeIndexed;
+	}
 
 	public void setCourse(Course course)
 	{
 		this.course = course;
 	}
 
-
-
 	public Subject getSubject()
 	{
 		return subject;
 	}
-
-
 
 	public void setSubject(Subject subject)
 	{
 		this.subject = subject;
 	}
 
-
-
 	public ScrapeHistory getScrapeId()
 	{
 		return scrapeId;
 	}
-
-
 
 	public void setScrapeId(ScrapeHistory scrapeId)
 	{
 		this.scrapeId = scrapeId;
 	}
 
-
-
 	public void setClassType(ClassType classType)
 	{
 		this.classType = classType;
 	}
-
-
-    
-    // Transient makes it invisible to the ORM, but still can be used in instance
-    
-    @Transient
-    public int ranking = 1;
-    
-
 	
-	public String getClassType() {
+	public void setShouldBeIndexed(Boolean value) 
+	{
+		this.shouldBeIndexed = value;
+	}
+
+	public String getClassType()
+	{
 		return this.classType.getClassType();
 	}
 }

--- a/searchIndex/src/main/java/org/ezcampus/search/hibernate/entityDAO/WordDAO.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/hibernate/entityDAO/WordDAO.java
@@ -1,61 +1,20 @@
 package org.ezcampus.search.hibernate.entityDAO;
 
-import java.io.Serializable;
-
 import org.ezcampus.search.data.StringHelper;
 import org.ezcampus.search.hibernate.entity.CourseData;
 import org.ezcampus.search.hibernate.entity.Word;
-import org.ezcampus.search.hibernate.util.HibernateUtil;
-import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.tinylog.Logger;
 
 public class WordDAO
 {
-
-	public static Word getWord(String input)
-	{
-		try (Session session = HibernateUtil.getSessionFactory().openSession())
-		{
-			Logger.debug("In session try statement");
-
-			return session.createQuery("FROM Word WHERE word = :entry", Word.class).setParameter("entry", input)
-					.setMaxResults(1).getSingleResultOrNull();
-		}
-	}
-
-	public static String getWordString(String input)
-	{
-		Word w = getWord(input);
-
-		if (w == null)
-		{
-			return null;
-		}
-
-		return w.getWordString();
-	}
-
-	public static Integer getWordId(String input)
-	{
-		Word w = getWord(input);
-
-		if (w == null)
-		{
-			return null;
-		}
-
-		return w.getId();
-	}
-
 	/**
 	 * Inserts the given word into the database, assumes there is already a transaction
 	 * @param wordString The word to insert
 	 * @param session The database connection
 	 * @return The inserted word, or the existing word
 	 */
-	public static Word insertWord_NT(String wordString, Session session)
+	public static Word insertWord_NT(Session session, String wordString)
 	{
 		if(wordString == null) 
 			return null;
@@ -65,13 +24,13 @@ public class WordDAO
 		if (cleaned.isEmpty()) 
 			return null;
 	
-		// Check if the word already exists in the database
-		Word existingWord = session.byNaturalId(Word.class).using("word", cleaned).load();
+		Word existingWord = session.byNaturalId(Word.class)
+								   .using("word", cleaned)
+								   .load();
 		
 		if (existingWord != null)
-		{
 			return existingWord;
-		}
+		
 
 		Word newWord = new Word(cleaned);
 		
@@ -80,67 +39,72 @@ public class WordDAO
 		return newWord;
 	}
 	
-	public static Word insertWord(String wordString, Session session)
-	{
-		if(wordString == null) return null;
-		String cleaned = StringHelper.cleanWord(wordString);
-		
-		if (cleaned.isEmpty()) return null;
-		
-		
-		Transaction tx = null;
-		try
-		{
-			// Check if the word already exists in the database
-			Word existingWord = session.byNaturalId(Word.class).using("word", cleaned).load();
-			if (existingWord != null)
-			{
-				return existingWord;
-			}
-
-			tx = session.beginTransaction();
-
-			Word newWord = new Word(cleaned);
-            session.persist(newWord);
-			tx.commit();
-
-			return newWord;
-		}
-		catch (HibernateException e)
-		{
-			Logger.error(e);
-			
-			if (tx != null && !tx.isActive())
-			{
-				tx.rollback();
-			}
-			throw e;
-		}
-	}
-
-	public static void linkWord(int wordId, int courseDataId)
-	{
-
-	}
 	
-	//Inserts a word, then inserts linked wordMap entry
-	
-	public static void insertLinkWord(String wordString, CourseData courseData, Session session) 
-	{
+	/**
+	 * Inserts the word and a mapping associating the word to the given CourseData
+	 * 
+ 	 * @param session The database connection
+ 	 * @param wordString The word to insert and associate
+ 	 * @param courseData The CourseData to associate with the word
+	 * @return The inserted word, or the existing word
+	 */
+	public static void insertLinkWord(Session session, String wordString, CourseData courseData) 
+	{	
 		Transaction tx = session.getTransaction();
 		
-		if(!tx.isActive())
-			tx.begin();
+		tx.begin();
 		
-		Word word = insertWord_NT(wordString, session);
+		Word word = insertWord_NT(session, wordString);
 		
-		if(word == null) {
-			Logger.debug("Cannot insertLinkWord because word {} was null after inserting", wordString);
+		if(word != null) 
+			WordMapDAO.insertMap_NT(session, word, courseData);
+		
+		tx.commit();
+	}
+	
+	
+	/**
+	 * Inserts the word and a mapping associating the word to the given CourseData
+	 * 
+ 	 * @param session The database connection
+ 	 * @param wordString The word to insert and associate
+ 	 * @param courseData The CourseData to associate with the word
+	 * @return The inserted word, or the existing word
+	 */
+	public static void insertLinkWordOptimized(Session session, String wordString, CourseData courseData) 
+	{	
+		if(wordString == null) 
+			return;
+		
+		String cleaned = StringHelper.cleanWord(wordString);
+	
+		if (cleaned.isEmpty()) 
+			return;
+		
+	
+		Word existingWord = session.byNaturalId(Word.class)
+								   .using("word", cleaned)
+								   .load();
+		
+		Transaction tx = session.getTransaction();
+		
+		tx.begin();
+		
+		if (existingWord != null)
+		{	
+			WordMapDAO.insertMap_NT(session, existingWord, courseData);
+			
+			tx.commit();
+			
 			return;
 		}
 		
-		WordMapDAO.insertMap_NT(word, courseData, session);
+		Word newWord = new Word(cleaned);
 		
-		tx.commit();
+        session.persist(newWord);
+	
+        WordMapDAO.insertMap_NT(session, newWord, courseData);
+		
+        tx.commit();
 	}
 }

--- a/searchIndex/src/main/java/org/ezcampus/search/hibernate/entityDAO/WordMapDAO.java
+++ b/searchIndex/src/main/java/org/ezcampus/search/hibernate/entityDAO/WordMapDAO.java
@@ -6,36 +6,21 @@ import org.ezcampus.search.hibernate.entity.WordMap;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.query.Query;
 import org.tinylog.Logger;
 
 public class WordMapDAO
 {
-
-	public static void insertMap(int wordId, int courseDataId, Session session) 
-	{
-		Word w = new Word();
-		w.setId(wordId);
-		
-		CourseData cd = new CourseData();
-		cd.setCourseDataId(courseDataId);
-		
-		insertMap(w, cd, session);
-	}
-
 	/**
 	 * Inserts the given mapping, assumes you are already in a transaction
 	 * @param word The word_id 
 	 * @param courseData The course_data_id
 	 * @param session The active database session
 	 */
-	public static void insertMap_NT(Word word, CourseData courseData, Session session) 
+	public static void insertMap_NT(Session session, Word word, CourseData courseData) 
 	{
-		WordMap map = session.createQuery("FROM WordMap m "
-				+ "JOIN FETCH m.word w "
-				+ "JOIN FETCH m.courseData cd "
-				+ "WHERE w = :word AND cd = :cd"
-				, WordMap.class)
+		final String HQL = "FROM WordMap m WHERE m.word = :word AND m.courseData = :cd";
+		
+		WordMap map = session.createQuery(HQL, WordMap.class)
 				.setParameter("word", word)
 				.setParameter("cd", courseData)
 				.setMaxResults(1)
@@ -45,51 +30,31 @@ public class WordMapDAO
 		{
 			map.increaseCountBy(1);
 		}
-		else {
+		else 
+		{
 			map = new WordMap(word, courseData, 1);
 		}
 
 		session.persist(map);
 	}
 	
-	public static void insertMap(Word word, CourseData courseData, Session session) 
+	
+	/**
+	 * Removes all the word mappings for the given course data
+	 * @param session
+	 * @param courseData
+	 */
+	public static void removeMap(Session session, CourseData courseData) 
 	{
-		Transaction tx = null;
-		try
-		{
-			WordMap map = session.createQuery("FROM WordMap m WHERE m.word = :word AND m.courseData = :cd", WordMap.class)
-					.setParameter("word", word)
-					.setParameter("cd", courseData)
-					.setMaxResults(1)
-					.getSingleResultOrNull();
-			
-			WordMap update ;
-			
-			if(map != null)
-			{
-				map.increaseCountBy(1);
-				
-				update = map;
-			}
-			else {
-				update = new WordMap(word, courseData, 1);
-			}
-			
-			tx = session.beginTransaction();
-
-			session.persist(update);
-			
-			tx.commit();
-		}
-		catch (HibernateException e)
-		{
-			Logger.error(e);
-			
-			if (tx != null && tx.isActive())
-			{
-				tx.rollback();
-			}
-			throw e;
-		}
+		Transaction tx = session.beginTransaction();
+		
+		final String HQL = "FROM WordMap m WHERE m.courseData = :cd";
+		
+		session.createQuery(HQL, WordMap.class)
+				.setParameter("cd", courseData)
+				.getResultStream()
+				.forEach(x -> session.remove(x));
+		
+		tx.commit();
 	}
 }


### PR DESCRIPTION
- Fixes the output of `/index/status`
- Removed lots of unused code
- Indexing a scrape now deletes all mappings for the CourseData before indexing, this ensures all mappings involving this data are new
- Indexing now updates the `should_be_indexed` column on the CourseData after indexing
- Added some extra word conversion for numbers ('1' -> 'one')
- No longer remove '-' when cleaning words
- No longer split on '_' when processing words
- No longer debug print words while they're being indexed (unless a specific bool is set in GlobalSettings)
